### PR TITLE
Add Dockerfile for x86 architecture

### DIFF
--- a/pocket2kindle-amd64/Dockerfile
+++ b/pocket2kindle-amd64/Dockerfile
@@ -1,0 +1,25 @@
+# dsantoro/pocket2kindle
+
+FROM ubuntu
+MAINTAINER Daniele Santoro "psyacca@gmail.com"
+
+# Update and install dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+	calibre \
+	nodejs \
+	npm \
+&& rm -rf /var/lib/apt/lists/*
+
+# Clone repository and install dependencies
+RUN git clone https://github.com/alvaroreig/pocket2kindle.git && \
+    cd pocket2kindle && \
+    npm install
+
+# Cleaning up
+RUN apt-get remove -y git && apt-get -y autoremove && apt-get clean && \
+    apt-get purge && \
+    rm -rf /tmp/* /var/tmp/*
+
+# Assuming that the env vars are passed on runtime, this command sends Pocket's content to Kindle.
+ENTRYPOINT cd pocket2kindle && nodejs index.js


### PR DESCRIPTION
I was not able to run your image on the following docker env:

```
Client:
 Version:      1.12.2
 API version:  1.24
 Go version:   go1.7.1
 Git commit:   bb80604
 Built:        Sun Oct 16 07:57:31 UTC 2016
 OS/Arch:      darwin/amd64

Server:
 Version:      1.12.2
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   bb80604
 Built:        Tue Oct 11 17:00:50 2016
 OS/Arch:      linux/amd64
```

For this reason I've created an ubuntu based docker image that works on my x86 env. It is available on docker hub: `dsantoro/pocket2kindle`.